### PR TITLE
Pin Renovate lockfile updates to Bun 1.3.14

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,4 +14,27 @@
     ':automergeMinor',
     ':automergeDigest',
   ],
+  constraints: {
+    // renovate: datasource=npm depName=bun
+    bun: '1.3.14',
+  },
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Update constraints.bun so lockfile updates use the project Bun version',
+      managerFilePatterns: ['/(^|/)renovate\\.json5$/'],
+      matchStrings: [
+        '// renovate: datasource=(?<datasource>[a-z0-9-]+?) depName=(?<depName>\\S+)\\s+bun:\\s*[\'"](?<currentValue>[^\'"]+)[\'"]',
+      ],
+      versioningTemplate: 'npm',
+    },
+  ],
+  packageRules: [
+    {
+      description: 'Keep .bun-version and constraints.bun on the same Bun release',
+      matchManagers: ['bun-version', 'custom.regex'],
+      matchPackageNames: ['bun'],
+      groupName: 'bun',
+    },
+  ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,25 +15,13 @@
     ':automergeDigest',
   ],
   constraints: {
-    // renovate: datasource=npm depName=bun
     bun: '1.3.14',
   },
-  customManagers: [
-    {
-      customType: 'regex',
-      description: 'Update constraints.bun so lockfile updates use the project Bun version',
-      managerFilePatterns: ['/(^|/)renovate\\.json5$/'],
-      matchStrings: [
-        '// renovate: datasource=(?<datasource>[a-z0-9-]+?) depName=(?<depName>\\S+)\\s+bun:\\s*[\'"](?<currentValue>[^\'"]+)[\'"]',
-      ],
-      versioningTemplate: 'npm',
-    },
-  ],
   packageRules: [
     {
       description: 'Keep .bun-version and constraints.bun on the same Bun release',
-      matchManagers: ['bun-version', 'custom.regex'],
-      matchPackageNames: ['bun'],
+      matchManagers: ['bun-version', 'renovate-config'],
+      matchPackageNames: ['bun', 'oven-sh/bun'],
       groupName: 'bun',
     },
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stops Renovate from rewriting `bun.lock` with a newer Bun than CI.

## Why

Renovate installs the latest stable Bun when `constraints.bun` is unset. After Bun 1.4 that produced `lockfileVersion: 3`, which Bun 1.3.14 (`.bun-version` / CI) cannot parse. That is what broke #782.

## Change

In `renovate.json5`:

- Pin `constraints.bun` to `1.3.14` so lockfile updates use the same Bun as CI
- Group that pin with the built-in `bun-version` manager so `.bun-version` and `constraints.bun` move together

The built-in [`renovate-config`](https://docs.renovatebot.com/modules/manager/renovate-config/) manager already extracts and updates Containerbase tool constraints, including `bun`. A custom regex manager is not needed.

## Validation

- `renovate-config-validator`: config validated successfully
- Lint: 0 errors
- Production build succeeds

This does not change application code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74e305bf-0f2a-4824-a070-dfb90f4cdec0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74e305bf-0f2a-4824-a070-dfb90f4cdec0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a supported Bun version constraint.
  * Grouped Bun-related updates together for easier maintenance.
  * Kept the project’s Bun version settings synchronized automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->